### PR TITLE
Add price_gp field for Equipment (Fixes #23)

### DIFF
--- a/script/fixtures/domains.json
+++ b/script/fixtures/domains.json
@@ -1611,6 +1611,51 @@
           "created_at": "2026-05-28T00:00:00Z",
           "id": "6849w0666b35f0f9ede6c0275",
           "url": "https://2e.aonprd.com/Weapons.aspx?ID=666"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0356b35f0f9ede6c0276",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=356"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0367b35f0f9ede6c0277",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=367"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0368b35f0f9ede6c0278",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=368"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0372b35f0f9ede6c0279",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=372"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0392b35f0f9ede6c0280",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=392"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0423b35f0f9ede6c0281",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=423"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0427b35f0f9ede6c0282",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=427"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0431b35f0f9ede6c0283",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=431"
+        },
+        {
+          "created_at": "2026-05-28T00:00:00Z",
+          "id": "6849w0438b35f0f9ede6c0284",
+          "url": "https://2e.aonprd.com/Weapons.aspx?ID=438"
         }
       ],
       "sitemaps": [],

--- a/script/fixtures/engine.json
+++ b/script/fixtures/engine.json
@@ -141,6 +141,9 @@
           },
           "deities": {
             "raw": {}
+          },
+          "price_gp": {
+            "raw": {}
           }
         },
         "search_fields": {

--- a/script/fixtures/pipeline.json
+++ b/script/fixtures/pipeline.json
@@ -126,7 +126,7 @@
       "grok": {
         "field": "full_html",
         "patterns": [
-          "<h1 class=\"title\"><a href=\"[A-Za-z]+\\.aspx\\?ID=%{NUMBER}[^\"]*\">%{DATA:better_title}</a>"
+          "<h1 class=\"title\">%{DATA}<a href=\"[A-Za-z]+\\.aspx\\?ID=%{NUMBER}[^\"]*\">%{DATA:better_title}</a>"
         ],
         "if": "ctx['better_title'] == null || ctx['better_title'] == ''",
         "ignore_missing": true,

--- a/script/fixtures/pipeline.json
+++ b/script/fixtures/pipeline.json
@@ -330,6 +330,13 @@
       }
     },
     {
+      "script": {
+        "description": "Extracts price_gp from body_content: parses 'Price N gp/sp/cp/pp' (with optional multi-denomination like '1 gp, 5 sp') and converts to gold pieces",
+        "source": "if (ctx[\"body_content\"] != null) {\n  def m = /Price (\\d[\\d,]*(?:\\.\\d+)?) (gp|sp|cp|pp)(?:, (\\d[\\d,]*(?:\\.\\d+)?) (gp|sp|cp|pp))?(?:, (\\d[\\d,]*(?:\\.\\d+)?) (gp|sp|cp|pp))?/.matcher(ctx[\"body_content\"]);\n  if (m.find()) {\n    double total = 0;\n    String n1 = m.group(1).replace(\",\", \"\");\n    String d1 = m.group(2);\n    double v1 = Double.parseDouble(n1);\n    if (d1.equals(\"pp\")) total += v1 * 10;\n    else if (d1.equals(\"gp\")) total += v1;\n    else if (d1.equals(\"sp\")) total += v1 / 10.0;\n    else if (d1.equals(\"cp\")) total += v1 / 100.0;\n    if (m.group(3) != null) {\n      String n2 = m.group(3).replace(\",\", \"\");\n      String d2 = m.group(4);\n      double v2 = Double.parseDouble(n2);\n      if (d2.equals(\"pp\")) total += v2 * 10;\n      else if (d2.equals(\"gp\")) total += v2;\n      else if (d2.equals(\"sp\")) total += v2 / 10.0;\n      else if (d2.equals(\"cp\")) total += v2 / 100.0;\n    }\n    if (m.group(5) != null) {\n      String n3 = m.group(5).replace(\",\", \"\");\n      String d3 = m.group(6);\n      double v3 = Double.parseDouble(n3);\n      if (d3.equals(\"pp\")) total += v3 * 10;\n      else if (d3.equals(\"gp\")) total += v3;\n      else if (d3.equals(\"sp\")) total += v3 / 10.0;\n      else if (d3.equals(\"cp\")) total += v3 / 100.0;\n    }\n    ctx[\"price_gp\"] = total;\n  }\n}",
+        "ignore_failure": true
+      }
+    },
+    {
       "grok": {
         "field": "stripped_html",
         "patterns": [

--- a/src/components/CustomResultView.tsx
+++ b/src/components/CustomResultView.tsx
@@ -1,5 +1,23 @@
 import {SearchResult} from "@elastic/search-ui";
 
+/**
+ * Formats a price_gp value (gold pieces as a float) into a human-readable
+ * currency string. Handles gp, sp, and cp denominations.
+ * Examples: 6.0 → "6 gp", 0.1 → "1 sp", 1.5 → "1 gp 5 sp", 0.01 → "1 cp"
+ */
+function formatPriceGp(priceGp: number): string {
+    // Work in copper to avoid floating-point precision issues
+    const totalCp = Math.round(priceGp * 100);
+    const gp = Math.floor(totalCp / 100);
+    const sp = Math.floor((totalCp % 100) / 10);
+    const cp = totalCp % 10;
+    const parts: string[] = [];
+    if (gp > 0) parts.push(`${gp} gp`);
+    if (sp > 0) parts.push(`${sp} sp`);
+    if (cp > 0) parts.push(`${cp} cp`);
+    return parts.length > 0 ? parts.join(" ") : `${priceGp} gp`;
+}
+
 const ACTION_COST_ICONS: Record<string, string> = {
     "free-action": "◇",
     "reaction": "↺",
@@ -40,6 +58,12 @@ export const CustomResultView = ({
     const itemLevel: string | undefined = isEquipment ? result.item_level?.raw : undefined;
     const bulk: string | undefined = isEquipment ? result.bulk?.raw : undefined;
     const usage: string | undefined = isEquipment ? result.usage?.raw : undefined;
+    const priceGpRaw: number | undefined = isEquipment && result.price_gp?.raw != null
+        ? Number(result.price_gp.raw)
+        : undefined;
+    const priceDisplay: string | undefined = priceGpRaw != null && !isNaN(priceGpRaw)
+        ? formatPriceGp(priceGpRaw)
+        : undefined;
     const spellLevel: string | undefined = isSpell ? result.spell_level?.raw : undefined;
     const traditions: string[] = isSpell && result.traditions?.raw
         ? (Array.isArray(result.traditions.raw) ? result.traditions.raw : [result.traditions.raw])
@@ -86,8 +110,23 @@ export const CustomResultView = ({
                     Spell {spellLevel}
                 </span>
             )}
-            {isEquipment && (itemLevel || bulk || usage) && (
+            {isEquipment && (itemLevel || bulk || usage || priceDisplay) && (
                 <span style={{ marginLeft: "0.5rem", display: "inline-flex", gap: "0.35rem", flexWrap: "wrap", flexShrink: 0 }}>
+                    {priceDisplay && (
+                        <span
+                            title="Price"
+                            style={{
+                                fontSize: "0.75rem",
+                                background: "#7a5c00",
+                                color: "#fff",
+                                padding: "1px 6px",
+                                borderRadius: "3px",
+                                whiteSpace: "nowrap",
+                            }}
+                        >
+                            {priceDisplay}
+                        </span>
+                    )}
                     {itemLevel && (
                         <span
                             title="Item Level"


### PR DESCRIPTION
## Summary

- **Pipeline**: adds a Painless script processor to `pipeline.json` that extracts price from `body_content`, parses denominations (gp, sp, cp, pp), handles multi-denomination prices like `1 gp, 5 sp`, and stores the result as a float in gold pieces (`price_gp`). The regex anchors on a digit after "Price" so prose mentions like "Price of the item" are safely ignored.
- **Engine**: adds `price_gp` to `result_fields` in `engine.json` so the field is returned by App Search queries.
- **Frontend**: adds a `formatPriceGp` helper that converts the gold float back to a readable currency string (e.g. `6.0 → "6 gp"`, `0.1 → "1 sp"`, `1.5 → "1 gp 5 sp"`), and displays it as a dark-gold badge alongside the existing Level/Bulk/Usage badges on Equipment result cards.

## Backend status

Pipeline and engine settings have been deployed. A full crawl is in progress and will populate `price_gp` on all Equipment (and Shields/Campsite) documents. Three sample docs were already verified:

| Item | Price text | price_gp |
|---|---|---|
| Thunder Snare | `Price 6 gp` | `6.0` |
| Animal Bed | `Price 1 sp` | `0.1` |
| Badger | `Price 1 gp, 5 sp` | `1.5` |

## Test plan

- [ ] After the full crawl completes, search for Equipment and confirm the price badge appears on items with known prices
- [ ] Verify no false positive `price_gp` on Spells/Feats/etc. (tested: "Clad in Metal" spell with `Price of the item` in body_content → no price_gp set)
- [ ] Confirm multi-denomination prices render correctly (e.g. "1 gp 5 sp" not "1.5 gp")

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)