### PR TITLE
Remove action cost icons from Classes results

### DIFF
--- a/script/fixtures/pipeline.json
+++ b/script/fixtures/pipeline.json
@@ -583,6 +583,15 @@
     },
     {
       "remove": {
+        "field": "num_actions",
+        "if": "ctx['category'] == 'Classes'",
+        "ignore_missing": true,
+        "ignore_failure": true,
+        "description": "Classes are not actions/spells; remove num_actions extracted from embedded actions within class page bodies"
+      }
+    },
+    {
+      "remove": {
         "field": [
           "action_cost",
           "body_one",


### PR DESCRIPTION
## Summary

- Class pages (Wizard, Monk, Summoner, etc.) embed action descriptions in their body content, causing the ingest pipeline to incorrectly extract `num_actions` from those embedded actions and display action cost icons in the UI
- Added a `remove` processor to the pipeline that strips `num_actions` for all documents with `category == "Classes"`, mirroring the existing traits removal for the same reason
- Applied an `update_by_query` to immediately clean up the 67 existing documents with incorrect `num_actions` values (no re-crawl needed)

## Test plan

- [x] Pipeline simulation confirms `num_actions` is removed for Classes documents
- [x] ES query shows 0 Classes documents with `num_actions` after fix
- [x] App Search API confirms `num_actions` is null for Classes (Wizard, Sorcerer, etc.)
- [x] Regression check: Actions category documents still have `num_actions` intact

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)