### PR TITLE
fix: extract requirements text from actions, remove false-positive Req pill

### DIFF
--- a/script/fixtures/engine.json
+++ b/script/fixtures/engine.json
@@ -112,7 +112,7 @@
           "source_book": {
             "raw": {}
           },
-          "requirements_flag": {
+          "requirements": {
             "raw": {}
           },
           "prerequisites_flag": {

--- a/script/fixtures/pipeline.json
+++ b/script/fixtures/pipeline.json
@@ -525,9 +525,9 @@
     },
     {
       "script": {
-        "source": "if (ctx['body_content'] != null && ctx['body_content'].contains('Requirements')) { ctx['requirements_flag'] = 'yes'; }",
+        "source": "if (ctx['full_html'] != null) { def m = /<b>Requirements<\\/b>([\\s\\S]*?)<hr/.matcher(ctx['full_html']); if (m.find()) { ctx['requirements'] = m.group(1).replaceAll('<[^>]+>', '').trim(); } }",
         "ignore_failure": true,
-        "description": "Sets requirements_flag when body_content mentions Requirements"
+        "description": "Extracts requirements text from <b>Requirements</b>...<hr stat block pattern in full_html"
       }
     },
     {
@@ -570,6 +570,24 @@
         "description": "Compute creature_level_bucket: Level -1 to 0, Levels 1-4, 5-8, 9-12, 13-16, 17-21, Level 22+",
         "source": "if (ctx['creature_level'] != null) {\n  try {\n    int lvl = Integer.parseInt(ctx['creature_level'].trim());\n    if (lvl <= 0) {\n      ctx['creature_level_bucket'] = 'Level -1 to 0';\n    } else if (lvl <= 4) {\n      ctx['creature_level_bucket'] = 'Levels 1–4';\n    } else if (lvl <= 8) {\n      ctx['creature_level_bucket'] = 'Levels 5–8';\n    } else if (lvl <= 12) {\n      ctx['creature_level_bucket'] = 'Levels 9–12';\n    } else if (lvl <= 16) {\n      ctx['creature_level_bucket'] = 'Levels 13–16';\n    } else if (lvl <= 21) {\n      ctx['creature_level_bucket'] = 'Levels 17–21';\n    } else {\n      ctx['creature_level_bucket'] = 'Level 22+';\n    }\n  } catch (Exception e) {}\n}",
         "ignore_failure": true
+      }
+    },
+    {
+      "remove": {
+        "field": "requirements",
+        "if": "ctx['url'] == null || !ctx['url'].contains('Actions.aspx')",
+        "ignore_missing": true,
+        "ignore_failure": true,
+        "description": "requirements field is only valid on Actions pages; class/feat pages embed action stat blocks which would otherwise cause false positives"
+      }
+    },
+    {
+      "remove": {
+        "field": "prerequisites_flag",
+        "if": "ctx['url'] == null || (!ctx['url'].contains('Feats.aspx') && !ctx['url'].contains('MythicFeats.aspx'))",
+        "ignore_missing": true,
+        "ignore_failure": true,
+        "description": "prerequisites_flag is only valid on Feats/MythicFeats pages"
       }
     },
     {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,7 +186,7 @@ const CONDITIONAL_FACET_FIELDS = [
   'spell_level_bucket',
   'spell_type',
   'num_actions',
-  'requirements_flag',
+  'requirements',
   'feat_level_bucket',
   'prerequisites_flag',
   'usage',
@@ -246,9 +246,6 @@ const conditionalFacets = {
   'num_actions': ({ filters }: { filters: Filter[] }) => {
     return filters.some(filter => filter.field === 'category' && (filterHasCategory(filter, 'Actions') || filterHasCategory(filter, 'Spells')))
   },
-  'requirements_flag': ({ filters }: { filters: Filter[] }) => {
-    return filters.some(filter => filter.field === 'category' && filterHasCategory(filter, 'Actions'))
-  },
   'feat_level_bucket': ({ filters }: { filters: Filter[] }) => {
     return filters.some(filter => filter.field === 'category' && filterHasCategory(filter, 'Feats'))
   },
@@ -305,7 +302,6 @@ const config: SearchDriverOptions = {
       spell_level_bucket: { type: "value", size: 15 },
       spell_type: { type: "value", size: 30 },
       num_actions: { type: "value", size: 10 },
-      requirements_flag: { type: "value", size: 2 },
       feat_level_bucket: { type: "value", size: 15 },
       prerequisites_flag: { type: "value", size: 2 },
       usage: { type: "value", size: 30 },
@@ -533,11 +529,6 @@ export default function App() {
                                 label="Number of Actions"
                                 isFilterable={false}
                                 view={NumActionsFacet}
-                            />
-                            <Facet
-                                field="requirements_flag"
-                                label="Has Requirements"
-                                isFilterable={false}
                             />
                             <Facet
                                 field="feat_level_bucket"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -186,7 +186,6 @@ const CONDITIONAL_FACET_FIELDS = [
   'spell_level_bucket',
   'spell_type',
   'num_actions',
-  'requirements',
   'feat_level_bucket',
   'prerequisites_flag',
   'usage',

--- a/src/components/CustomResultView.tsx
+++ b/src/components/CustomResultView.tsx
@@ -51,7 +51,6 @@ export const CustomResultView = ({
     onClickLink: () => void;
 }) => {
     const numActions: string | undefined = result.num_actions?.raw;
-    const hasRequirements: boolean = result.requirements_flag?.raw === "yes";
     const category: string | undefined = result.category?.raw;
     const isEquipment: boolean = typeof category === "string" && EQUIPMENT_CATEGORIES.has(category);
     const isSpell: boolean = category === "Spells";
@@ -199,23 +198,14 @@ export const CustomResultView = ({
                 <li>
                     <span className="sui-result__key">category</span>
                     <span className="sui-result__value">{result.category?.raw}</span>
-                    {hasRequirements && (
-                        <span
-                            title="Has Requirements"
-                            style={{
-                                marginLeft: "0.5rem",
-                                fontSize: "0.75rem",
-                                background: "#6c757d",
-                                color: "#fff",
-                                padding: "1px 6px",
-                                borderRadius: "3px",
-                                verticalAlign: "middle",
-                            }}
-                        >
-                            Req
-                        </span>
-                    )}
                 </li>
+                {
+                    result.requirements?.raw &&
+                    <li>
+                        <span className="sui-result__key">requirements</span>
+                        <span className="sui-result__value">{result.requirements?.raw}</span>
+                    </li>
+                }
                 {
                     result.sub_category?.raw &&
                     <li>


### PR DESCRIPTION
## Summary

- Fixes false-positive "Req" pill on class cards (e.g. Animist) — the old pipeline checked for the word "Requirements" anywhere in body_content, which matched prose text on class pages
- Replaces the boolean `requirements_flag` with a `requirements` text field extracted via regex from the `<b>Requirements</b>...<hr` stat block pattern in `full_html`
- Gates the field to Actions pages only via a pipeline `remove` processor (class pages embed action stat blocks inline, which caused false positives)
- Gates `prerequisites_flag` to Feats/MythicFeats pages only (same reason)
- UI now shows `requirements: <text>` as a plain detail row on action cards, only when present
- Removes the "Has Requirements" yes/no facet (replaced by the actual text value)

## Test plan
- [ ] Animist class card: no requirements row
- [ ] Quick Alchemy action card: shows `requirements:` row with actual text after crawl completes
- [ ] A feat card: no requirements row
- [ ] Actions category filter still works
- [ ] "Has Requirements" facet is gone from sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)