### PR TITLE
fix: clean up orphaned content-hash constraints to unblock weapon indexing

### DIFF
--- a/.claude/skills/work-github-issue/SKILL.md
+++ b/.claude/skills/work-github-issue/SKILL.md
@@ -18,6 +18,7 @@ Read the relevant gotcha file **before** starting work in that area. Paths are r
 | Matching against `full_html`          | `gotchas/crawler-html-normalization.md` |
 | Adding a new facet field              | `gotchas/app-search-facets.md`         |
 | Running a batch crawl (100+ pages)    | `gotchas/batch-crawl-timing.md`        |
+| Pages being fetched but not indexed   | `gotchas/content-hash-constraints.md`  |
 
 ## 1. Understand the issue
 

--- a/.claude/skills/work-github-issue/gotchas/content-hash-constraints.md
+++ b/.claude/skills/work-github-issue/gotchas/content-hash-constraints.md
@@ -1,0 +1,43 @@
+# Gotcha: Content Hash Constraint Orphans Block Re-indexing
+
+## Symptom
+
+Pages are being fetched by the crawler (url-fetch + url-extracted events in logs) but don't appear in `search-nethys`. The `url-output` event shows:
+
+```
+event.outcome: failure
+message: "Unexpected error while ingesting a document into Elasticsearch:
+  '<config_oid>|<hash>' not unique value for field configuration_oid, content_hash"
+```
+
+## Root Cause
+
+The crawler uses `.ent-search-actastic-crawler2_content_metadata-configuration_oid-content_hash-unique-constraint` to enforce that no two documents have the same content hash. When a document is deleted from `content_metadata` (e.g., after a full re-index), its constraint entry is **not cleaned up**.
+
+The next time the crawler tries to index a page whose content hash matches an orphaned entry, it gets a uniqueness violation and fails to index it.
+
+When a large batch of documents is replaced (full crawl re-index), thousands of constraint entries become orphaned simultaneously, causing widespread indexing failures.
+
+## Detection
+
+Run `script/check-dead-links.sh`. Look for:
+- `Constraint orphan estimate` significantly > 0 (warning threshold: 5,000+)
+- Large discrepancy between constraint count and content_metadata count
+
+Or check crawler logs for `url-output failure` events with `not unique value` in the message.
+
+## Fix
+
+```bash
+script/fix-content-hash-constraints.sh          # dry run: shows how many to delete
+script/fix-content-hash-constraints.sh --confirm  # actually deletes orphaned entries
+```
+
+After cleanup, trigger a full crawl:
+```bash
+script/trigger-crawl.sh
+```
+
+## History
+
+May 2026: 41,779 orphaned constraints accumulated from the initial 2023 crawl, blocking ~10,000+ pages from being updated. Cleaned up manually via delete_by_query.

--- a/script/check-dead-links.sh
+++ b/script/check-dead-links.sh
@@ -59,8 +59,23 @@ if [[ "$URL_META_COUNT" -gt 200000 ]]; then
 fi
 echo
 
+# Content hash constraint health
+# When orphaned constraint entries accumulate, they block re-indexing of changed pages.
+# Healthy: constraint count ≈ content_metadata count. If constraint >> metadata, run fix-content-hash-constraints.sh.
+http_call GET "${ES_HOST}/.ent-search-actastic-crawler2_content_metadata-configuration_oid-content_hash-unique-constraint/_count" "$AUTH"
+CONSTRAINT_COUNT=$(echo "$HTTP_BODY" | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])")
+http_call GET "${ES_HOST}/.ent-search-actastic-crawler2_content_metadata/_count" "$AUTH"
+METADATA_COUNT=$(echo "$HTTP_BODY" | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])")
+ORPHANED_ESTIMATE=$((CONSTRAINT_COUNT - METADATA_COUNT))
+echo "Content hash constraints: $CONSTRAINT_COUNT (content_metadata docs: $METADATA_COUNT, orphaned estimate: $ORPHANED_ESTIMATE)"
+if [[ "$ORPHANED_ESTIMATE" -gt 5000 ]]; then
+  echo "WARNING: Large number of orphaned constraints — run script/fix-content-hash-constraints.sh --confirm to clean up"
+fi
+echo
+
 echo "=== Summary ==="
 echo "  Total documents:            $TOTAL"
 echo "  Session-token URL docs:     $SESSION_COUNT"
 echo "  Page Not Found title docs:  $PNF_COUNT"
 echo "  URL metadata records:       $URL_META_COUNT"
+echo "  Constraint orphan estimate: $ORPHANED_ESTIMATE"

--- a/script/fix-content-hash-constraints.sh
+++ b/script/fix-content-hash-constraints.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# Fix: delete orphaned content_hash unique constraint entries.
+#
+# The crawler uses a unique constraint index to prevent duplicate documents with
+# the same content hash. When documents are deleted from the content_metadata
+# index (e.g., after a full re-index), the constraint entries are NOT cleaned up.
+# These orphaned locks prevent the crawler from indexing updated versions of pages
+# whose content has changed, producing "not unique value for field
+# configuration_oid, content_hash" errors in the crawler logs.
+#
+# This script identifies and deletes constraint entries that point to document IDs
+# no longer present in the content_metadata index.
+#
+# Safe to run while crawls are in progress, but ideally run when no crawl is active.
+# After running, trigger a full crawl to re-index previously blocked pages.
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh"
+
+ES_HOST=$(get_es_host)
+AUTH="Authorization: ApiKey $ES_API_KEY"
+CONSTRAINT_INDEX=".ent-search-actastic-crawler2_content_metadata-configuration_oid-content_hash-unique-constraint"
+METADATA_INDEX=".ent-search-actastic-crawler2_content_metadata"
+
+echo "=== Content Hash Constraint Cleanup ==="
+echo
+
+# Count before
+http_call GET "${ES_HOST}/${CONSTRAINT_INDEX}/_count" "$AUTH"
+BEFORE=$(echo "$HTTP_BODY" | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])")
+http_call GET "${ES_HOST}/${METADATA_INDEX}/_count" "$AUTH"
+META_COUNT=$(echo "$HTTP_BODY" | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])")
+
+echo "Constraint entries: $BEFORE"
+echo "Content metadata docs: $META_COUNT"
+echo
+
+# Get all valid document ID prefixes from content_metadata
+# Each content_metadata doc has an 'id' field like:
+#   "configuration_oid:...|document_id:<hex_id>"
+# Constraint entries reference these via crawler2_content_metadatum_id.
+# We get all current content_metadata IDs and delete constraint entries
+# that don't reference any of them.
+
+echo "Fetching valid document IDs from content_metadata..."
+http_call POST "${ES_HOST}/${METADATA_INDEX}/_search" "$AUTH" \
+  -d "{\"size\": 10000, \"_source\": [\"id\"]}"
+
+VALID_IDS=$(echo "$HTTP_BODY" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+hits = data['hits']['hits']
+ids = []
+for h in hits:
+    raw_id = h['_source']['id']
+    # Extract just the document_id part
+    if 'document_id:' in raw_id:
+        doc_id = raw_id.split('document_id:')[1]
+        ids.append(doc_id)
+print(json.dumps(ids))
+")
+
+VALID_COUNT=$(echo "$VALID_IDS" | python3 -c "import json,sys; print(len(json.load(sys.stdin)))")
+echo "Valid document IDs: $VALID_COUNT"
+
+# Build a terms query to match valid constraint entries
+# Delete all constraint entries NOT in this list
+DELETE_QUERY=$(echo "$VALID_IDS" | python3 -c "
+import json, sys
+ids = json.load(sys.stdin)
+# Build must_not terms query — constraint entries whose metadatum_id contains one of the valid doc IDs
+# Since IDs are hex strings, we can use a wildcard per ID (slow but correct for small sets)
+# For large sets, use terms on a keyword field or regexp
+# The crawler2_content_metadatum_id field looks like:
+#   'configuration_oid:<oid>|document_id:<doc_id>'
+# We want to DELETE entries where no valid doc_id appears
+should_clauses = [{'wildcard': {'crawler2_content_metadatum_id': f'*{doc_id}'}} for doc_id in ids]
+query = {
+    'query': {
+        'bool': {
+            'must_not': [
+                {'bool': {'should': should_clauses, 'minimum_should_match': 1}}
+            ]
+        }
+    }
+}
+print(json.dumps(query))
+")
+
+# Count orphaned entries first
+http_call POST "${ES_HOST}/${CONSTRAINT_INDEX}/_count" "$AUTH" -d "$DELETE_QUERY"
+ORPHANED=$(echo "$HTTP_BODY" | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])")
+echo "Orphaned constraint entries to delete: $ORPHANED"
+
+if [[ "$ORPHANED" -eq 0 ]]; then
+  echo "No orphaned entries found. Nothing to do."
+  exit 0
+fi
+
+if [[ "${1:-}" != "--confirm" ]]; then
+  echo
+  echo "Dry run complete. To actually delete, run with --confirm"
+  exit 0
+fi
+
+echo
+echo "Deleting $ORPHANED orphaned constraint entries..."
+http_call POST "${ES_HOST}/${CONSTRAINT_INDEX}/_delete_by_query" "$AUTH" -d "$DELETE_QUERY"
+DELETED=$(echo "$HTTP_BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('deleted', 0))")
+FAILURES=$(echo "$HTTP_BODY" | python3 -c "import json,sys; d=json.load(sys.stdin); print(len(d.get('failures', [])))")
+
+echo "Deleted: $DELETED"
+echo "Failures: $FAILURES"
+
+# Refresh and report final counts
+curl -s -H "$AUTH" -X POST "${ES_HOST}/${CONSTRAINT_INDEX}/_refresh" > /dev/null
+http_call GET "${ES_HOST}/${CONSTRAINT_INDEX}/_count" "$AUTH"
+AFTER=$(echo "$HTTP_BODY" | python3 -c "import json,sys; print(json.load(sys.stdin)['count'])")
+
+echo
+echo "=== Done ==="
+echo "Constraint entries before: $BEFORE"
+echo "Constraint entries after:  $AFTER"
+echo
+echo "Trigger a full crawl to re-index previously blocked pages:"
+echo "  script/trigger-crawl.sh"


### PR DESCRIPTION
## Summary

- Found root cause of issue #41: 41,779 orphaned entries in the crawler's content-hash unique constraint index were blocking re-indexing of ~10,000+ pages (not just weapons)
- Every time a page's content changed since the initial 2023 crawl, the crawler fetched and extracted it but then failed with `not unique value for field configuration_oid, content_hash`
- Manually deleted orphaned entries and verified hatchet (Weapons.aspx?ID=382) now indexes successfully
- Triggered a full crawl to re-index all previously blocked pages

## What changed

- `script/fix-content-hash-constraints.sh` — new script to detect and delete orphaned constraint entries (dry-run by default, `--confirm` to execute)
- `script/check-dead-links.sh` — added constraint health check to the diagnostic report
- `.claude/skills/work-github-issue/gotchas/content-hash-constraints.md` — documents this failure pattern for future investigations
- `CLAUDE.md` — documents the constraint health issue and references the new script (local-only, not tracked by git)

## Test plan

- [x] Verified hatchet (Weapons.aspx?ID=382) is now in search-nethys index with `last_crawled_at: 2026-05-29`
- [x] Verified hatchet appears in App Search API results for "hatchet" query with Weapons filter
- [x] Full crawl triggered to re-index all other previously blocked pages
- [x] Constraint index reduced from 43,135 to 1,356 entries (1,356 valid + 0 orphaned)

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)
