### PR TITLE
perf: gate ingest pipeline processors by page type

### DIFF
--- a/script/fixtures/pipeline.json
+++ b/script/fixtures/pipeline.json
@@ -200,6 +200,7 @@
       "html_strip": {
         "field": "full_html",
         "target_field": "stripped_html",
+        "if": "ctx['url'] != null && (ctx['url'].contains('Spells.aspx') || ctx['url'].contains('Weapons.aspx') || ctx['url'].contains('Equipment.aspx') || ctx['url'].contains('Armor.aspx') || ctx['url'].contains('Shields.aspx'))",
         "ignore_missing": true,
         "ignore_failure": true
       }
@@ -210,6 +211,7 @@
         "patterns": [
           "Traditions %{DATA:traditions}\\n"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Spells.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'traditions' from stripped_html"
@@ -222,6 +224,7 @@
           "Bloodline %{DATA:bloodlines}\\n",
           "Bloodlines %{DATA:bloodlines}\\n"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Spells.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'bloodlines' from stripped_html"
@@ -233,6 +236,7 @@
         "patterns": [
           "Cast %{DATA:casting_components}\\n"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Spells.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'casting components' from stripped_html"
@@ -247,6 +251,7 @@
           "Range %{DATA:range}; Targets %{DATA:target}\\n",
           "Range %{DATA:range}\\n"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Spells.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'range', 'area', and 'target' from stripped_html"
@@ -258,6 +263,7 @@
         "patterns": [
           "Saving Throw %{DATA:save}\\n"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Spells.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'save' from stripped_html"
@@ -269,6 +275,7 @@
         "patterns": [
           "Deities %{DATA:deities}\\n"
         ],
+        "if": "ctx['url'] != null && (ctx['url'].contains('Spells.aspx') || ctx['url'].contains('Deities.aspx'))",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'deities' from stripped_html"
@@ -280,6 +287,7 @@
         "patterns": [
           "Duration %{DATA:duration}\\n"
         ],
+        "if": "ctx['url'] != null && (ctx['url'].contains('Spells.aspx') || ctx['url'].contains('Actions.aspx'))",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'duration' from stripped_html"
@@ -291,6 +299,7 @@
         "patterns": [
           "Spell List %{DATA:spell_list}\\n"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Spells.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'spell_list' from stripped_html"
@@ -302,6 +311,7 @@
         "patterns": [
           "\\nHands %{NUMBER:hands}\\n"
         ],
+        "if": "ctx['url'] != null && (ctx['url'].contains('Weapons.aspx') || ctx['url'].contains('Equipment.aspx'))",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'hands' from stripped_html"
@@ -313,6 +323,7 @@
         "patterns": [
           "Usage %{DATA:usage};"
         ],
+        "if": "ctx['url'] != null && (ctx['url'].contains('Equipment.aspx') || ctx['url'].contains('Armor.aspx'))",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'usage' (equipment slot) from stripped_html"
@@ -324,6 +335,7 @@
         "patterns": [
           "Bulk %{DATA:bulk}[;\\n]"
         ],
+        "if": "ctx['url'] != null && (ctx['url'].contains('Weapons.aspx') || ctx['url'].contains('Equipment.aspx') || ctx['url'].contains('Armor.aspx'))",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'bulk' from stripped_html"
@@ -345,6 +357,7 @@
           "Hardness %{NUMBER:hardness}, HP %{NUMBER:durability}, BT %{NUMBER:break_threshold}",
           "Hardness %{NUMBER:hardness}, HP %{NUMBER:durability} \\(BT %{NUMBER:break_threshold}\\)"
         ],
+        "if": "ctx['url'] != null && (ctx['url'].contains('Shields.aspx') || ctx['url'].contains('Equipment.aspx'))",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts 'hardness', 'durability' (HP), and 'break_threshold' (BT) from stripped_html"
@@ -478,6 +491,7 @@
         "patterns": [
           "<span style=\\\"margin-left:auto; margin-right:0\\\">Item %{NUMBER:item_level}"
         ],
+        "if": "ctx['url'] != null && (ctx['url'].contains('Equipment.aspx') || ctx['url'].contains('Shields.aspx') || ctx['url'].contains('Weapons.aspx'))",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts item level from Equipment/Shields pages"
@@ -489,6 +503,7 @@
         "patterns": [
           "<span style=\\\"margin-left:auto; margin-right:0\\\">Feat %{NUMBER:feat_level}"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Feats.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts feat level from Feats pages"
@@ -500,6 +515,7 @@
         "patterns": [
           "<span style=\\\"margin-left:auto; margin-right:0\\\">Creature %{NUMBER:creature_level}"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Monsters.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts creature level from margin-left:auto span on Monsters pages"
@@ -511,6 +527,7 @@
         "patterns": [
           "<span class=\\\"traitsize\\\"><a href[^>]+>%{DATA:creature_size}</a>"
         ],
+        "if": "ctx['url'] != null && ctx['url'].contains('Monsters.aspx')",
         "ignore_missing": true,
         "ignore_failure": true,
         "description": "Extracts creature size from traitsize span on Monsters pages"
@@ -519,6 +536,7 @@
     {
       "script": {
         "source": "if (ctx['full_html'] != null && ctx['full_html'].contains('<b>Prerequisites</b>')) { ctx['prerequisites_flag'] = 'yes'; }",
+        "if": "ctx['url'] != null && ctx['url'].contains('Feats.aspx')",
         "ignore_failure": true,
         "description": "Sets prerequisites_flag when full_html contains a Prerequisites stat block label"
       }
@@ -526,6 +544,7 @@
     {
       "script": {
         "source": "if (ctx['full_html'] != null) { def m = /<b>Requirements<\\/b>([\\s\\S]*?)<hr/.matcher(ctx['full_html']); if (m.find()) { ctx['requirements'] = m.group(1).replaceAll('<[^>]+>', '').trim(); } }",
+        "if": "ctx['url'] != null && ctx['url'].contains('Actions.aspx')",
         "ignore_failure": true,
         "description": "Extracts requirements text from <b>Requirements</b>...<hr stat block pattern in full_html"
       }


### PR DESCRIPTION
## Summary

- **Root cause of crawl timeouts**: Every ingest pipeline processor ran unconditionally on every page. Large pages like Sources.aspx (239KB) and Rules.aspx (191KB) were running 11+ regex scans against huge `stripped_html` and `full_html` strings that could never produce a hit for those page types, causing ES write thread to exceed the 30s read timeout.
- **Fix**: Added `if` guards to 18 processors so each only executes on page types where its target field can actually appear (identified by URL pattern e.g. `Spells.aspx`, `Monsters.aspx`).
- **Expected outcome**: Large non-spell/non-equipment pages now skip ~15 processors. Estimated indexing time reduction from ~30s to ~2–3s for pages like Sources.aspx.

### Processors guarded

| Group | Processors | Guard |
|-------|------------|-------|
| `html_strip` (creates `stripped_html`) | [22] | Spells / Weapons / Equipment / Armor / Shields |
| stripped_html groks: traditions, bloodlines, casting_components, range/area/target, save, spell_list | [23–27, 30] | Spells only |
| stripped_html grok: deities | [28] | Spells or Deities |
| stripped_html grok: duration | [29] | Spells or Actions |
| stripped_html groks: hands | [31] | Weapons or Equipment |
| stripped_html grok: usage | [32] | Equipment or Armor |
| stripped_html grok: bulk | [33] | Weapons, Equipment, or Armor |
| stripped_html grok: hardness/HP/BT | [35] | Shields or Equipment |
| full_html grok: item_level | [48] | Equipment, Shields, or Weapons |
| full_html grok: feat_level | [49] | Feats |
| full_html grok: creature_level | [50] | Monsters |
| full_html grok: creature_size | [51] | Monsters |
| script: prerequisites_flag | [52] | Feats |
| script: requirements | [53] | Actions |

### Unchanged (already guarded or universal)
- [42] spell_level from full_html — already has `if spell_level == null`
- [44–47] num_actions chain — already gated with `if num_actions == null`
- [54] rarity — appears on many page types
- [55] source_book — appears on nearly all pages
- [60–63] remove processors — kept as safety nets

## Verification

Spot-checked live index before making changes — confirmed fields are populated for the correct categories:
- Weapons: `hands` present on Weapons.aspx docs
- Feats: `feat_level` + `prerequisites_flag` present on Feats.aspx docs
- Monsters: `creature_level` + `creature_size` present on Monsters.aspx docs
- Spells: `save` + `duration` + `traditions` present on Spells.aspx docs
- Equipment: `usage` + `item_level` + `bulk` present on Equipment.aspx docs

## Deploy note

This PR only updates `script/fixtures/pipeline.json`. Run `script/update-pipeline.sh` manually after the current crawl completes to deploy.

Fixes #41