### PR TITLE
feat: detect legacy content pages and show Legacy pill

### DIFF
--- a/script/fixtures/pipeline.json
+++ b/script/fixtures/pipeline.json
@@ -592,6 +592,15 @@
       }
     },
     {
+      "set": {
+        "field": "is_legacy",
+        "value": true,
+        "if": "ctx['full_html'] != null && ctx['full_html'].contains('legacy-content-warning')",
+        "ignore_failure": true,
+        "description": "Sets is_legacy=true for pre-remaster pages that carry the legacy-content-warning CSS class"
+      }
+    },
+    {
       "remove": {
         "field": "requirements",
         "if": "ctx['url'] == null || !ctx['url'].contains('Actions.aspx')",

--- a/src/components/CustomResultView.tsx
+++ b/src/components/CustomResultView.tsx
@@ -51,6 +51,7 @@ export const CustomResultView = ({
     onClickLink: () => void;
 }) => {
     const numActions: string | undefined = result.num_actions?.raw;
+    const isLegacy: boolean = !!result.is_legacy?.raw;
     const category: string | undefined = result.category?.raw;
     const isEquipment: boolean = typeof category === "string" && EQUIPMENT_CATEGORIES.has(category);
     const isSpell: boolean = category === "Spells";
@@ -91,6 +92,23 @@ export const CustomResultView = ({
                     }}
                 >
                     {ACTION_COST_ICONS[numActions] ?? numActions}
+                </span>
+            )}
+            {isLegacy && (
+                <span
+                    title="Pre-remaster legacy content"
+                    style={{
+                        marginLeft: "0.5rem",
+                        fontSize: "0.75rem",
+                        background: "#555",
+                        color: "#fff",
+                        padding: "1px 6px",
+                        borderRadius: "3px",
+                        whiteSpace: "nowrap",
+                        flexShrink: 0,
+                    }}
+                >
+                    Legacy
                 </span>
             )}
             {isSpell && spellLevel && (


### PR DESCRIPTION
## Summary

- Adds a pipeline processor (`set is_legacy = true`) triggered by the `legacy-content-warning` CSS class that AoN uses on all pre-remaster pages — more reliable than URL pattern matching (e.g. `?NoRedirect=1`)
- Adds a grey **Legacy** pill in `CustomResultView` header so users can distinguish pre-remaster content from remastered equivalents

## Why

Surfaced while investigating #41 — the Sorcerer class appears 3 times in search results, including the pre-remaster Core Rulebook version (`Classes.aspx?ID=11`) and the remastered Player Core 2 version (`Classes.aspx?ID=62`). Rather than hiding legacy content, we should label it clearly.

## Deploy

After merging:
1. `script/update-pipeline.sh` to deploy the new processor
2. Full crawl — legacy pages will get `is_legacy=true` as they are indexed; UI pill appears once the field propagates through App Search schema auto-detection
3. `npm run deploy` for the frontend change

## Test plan
- [ ] Run `script/update-pipeline.sh`
- [ ] Crawl a known legacy URL (e.g. `https://2e.aonprd.com/Classes.aspx?ID=11&NoRedirect=1`) and confirm `is_legacy: true` in ES doc
- [ ] Crawl a remastered URL (e.g. `https://2e.aonprd.com/Classes.aspx?ID=62`) and confirm no `is_legacy` field
- [ ] Search sorcerer on deployed site — Legacy pill appears on pre-remaster result only

Generated with Claude Code